### PR TITLE
Replace query param for reserved keyword 'from'

### DIFF
--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -1261,6 +1261,11 @@ class HTTP:
             if query is not None:
                 req_params = {k: v for k, v in query.items() if
                               v is not None}
+
+                # Replace query param 'from_time' since 'from' keyword is 
+                # reserved.
+                if ('from_time' in req_params):
+                    req_params['from'] = req_params.pop('from_time')
             else:
                 req_params = {}
 

--- a/tests/test_pybit.py
+++ b/tests/test_pybit.py
@@ -7,34 +7,34 @@ ws = WebSocket('wss://stream.bybit.com/realtime',
 
 class HTTPTest(unittest.TestCase):
 
-    def test_get_orderbook(self):
+    def test_orderbook(self):
         self.assertEqual(
-            session.get_orderbook(symbol='BTCUSD')['ret_msg'],
+            session.orderbook(symbol='BTCUSD')['ret_msg'],
             'OK'
         )
 
-    def test_get_klines(self):
+    def test_query_kline(self):
         self.assertEqual(
-            (session.get_klines(symbol='BTCUSD', interval='1', 
+            (session.query_kline(symbol='BTCUSD', interval='1', 
                 from_time=int(time.time())-60*60)['ret_msg']),
             'OK'
         )
     
-    def test_get_tickers(self):
+    def test_latest_information_for_symbol(self):
         self.assertEqual(
-            session.get_tickers()['ret_msg'],
+            session.latest_information_for_symbol()['ret_msg'],
             'OK'
         )
 
-    def test_get_trading_records(self):
+    def test_public_trading_records(self):
         self.assertEqual(
-            session.get_trading_records(symbol='BTCUSD')['ret_msg'],
+            session.public_trading_records(symbol='BTCUSD')['ret_msg'],
             'OK'
         )
 
-    def test_get_symbols(self):
+    def test_query_symbol(self):
         self.assertEqual(
-            session.get_symbols()['ret_msg'],
+            session.query_symbol()['ret_msg'],
             'OK'
         )
 


### PR DESCRIPTION
Since 'from' is a reserved keyword and 2 of the Bybit API endpoints use 'from' as a query parameter, this allows the use of 'from_time' as a keyword argument when calling these endpoints.

I have updated the tests for the HTTP class as well.

Closes #14 