### PR TITLE
[logging] switched init of logger

### DIFF
--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -105,12 +105,19 @@ class HTTP:
             self.endpoint = endpoint
 
         # Setup logger.
-        logging.basicConfig(
-            level=logging_level,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S'
-        )
+
         self.logger = logging.getLogger(__name__)
+
+        if len(logging.root.handlers) == 0:
+            #no handler on root logger set -> we add handler just for this logger to not mess with custom logic from outside
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter(fmt='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                                                   datefmt='%Y-%m-%d %H:%M:%S'
+                                                   )
+                                 )
+            handler.setLevel(logging_level)
+            self.logger.addHandler(handler)
+
         self.logger.debug('Initializing HTTP session.')
         self.log_requests = log_requests
 
@@ -1554,12 +1561,18 @@ class WebSocket:
         self.wsName = 'Authenticated' if api_key else 'Non-Authenticated'
 
         # Setup logger.
-        logging.basicConfig(
-            level=logging_level,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
+
+        if len(logging.root.handlers) == 0:
+            # no handler on root logger set -> we add handler just for this logger to not mess with custom logic from outside
+            handler = logging.StreamHandler()
+            handler.setFormatter(logging.Formatter(fmt='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                                                   datefmt='%Y-%m-%d %H:%M:%S'
+                                                   )
+                                 )
+            handler.setLevel(logging_level)
+            self.logger.addHandler(handler)
+
         self.logger.debug(f'Initializing {self.wsName} WebSocket.')
 
         # Ensure authentication for private topics.


### PR DESCRIPTION
to allow outside code to use custom loggers without any handler on the root logger.

pro: if outside code doesn't use the root logger (no handler on it), we still add the stream-handler to our logger, so behaviour is basically the same.

if outside already called basic config, this call anyway never did anything and still the root logger is used.

possible con: if the outside code relies on pybit to initialize the logging and add a handler to the root-logger, those projects need to add this basicConfig call themself now.

what do you think?