### PR TITLE
remove /v2/private/position/switch-mode, not yet released to mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2021-07-15
+### Remoed
+- Removed `position_mode_switch()` as the endpoint has not been released to mainnet yet
+
 ## [1.2.0] - 2021-07-09
 
 ### Added

--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -35,7 +35,7 @@ except ImportError:
     from json.decoder import JSONDecodeError
 
 # Versioning.
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 
 
 class HTTP:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='pybit',
-    version='1.2.0',
+    version='1.2.1',
     description='Python3 Bybit HTTP/WebSocket API Connector', 
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Related to https://github.com/bybit-exchange/docs/pull/255

Removes `position_mode_switch()` because it's only on testnet right now. 