### PR TITLE
Update __reduce__ of exceptions to support pickling

### DIFF
--- a/pybit/exceptions.py
+++ b/pybit/exceptions.py
@@ -18,6 +18,10 @@ class FailedRequestError(Exception):
             f'.\nRequest → {request}.'
         )
 
+    def __reduce__(self):
+        return self.__class__, (self.request, self.message, self.status_code,
+                                self.time)
+
 
 class InvalidRequestError(Exception):
     """
@@ -38,3 +42,7 @@ class InvalidRequestError(Exception):
             f'{message.capitalize()} (ErrCode: {status_code}) (ErrTime: {time})'
             f'.\nRequest → {request}.'
         )
+
+    def __reduce__(self):
+        return self.__class__, (self.request, self.message, self.status_code,
+                                self.time)


### PR DESCRIPTION
This fixes the inability to pickle the custom exception classes, e.g.
```python
import pickle
import pybit

e = pybit.exceptions.InvalidRequestError("foo", "bar", "baz", "quux")
print(e)
pickled = pickle.dumps(e)
unpickled = pickle.loads(pickled)  # TypeError: __init__() missing 3 required positional arguments: 'message', 'status_code', and 'time'

print(e)
```
