### PR TITLE
fix AttributeError when kwargs not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2021-10-07
+### Modified
+- Fixed methods like `query_symbol()` (which have no API parameters) not working following the spot update
+
 ## [1.3.0] - 2021-09-24
 ### Added
 - Implemented the Spot API in `HTTP`

--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -35,7 +35,7 @@ except ImportError:
     from json.decoder import JSONDecodeError
 
 # Versioning.
-VERSION = '1.3.0'
+VERSION = '1.3.1'
 
 
 class HTTP:

--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -1695,11 +1695,14 @@ class HTTP:
 
         """
 
-        # Store original recv_window.
-        recv_window = self.recv_window
+        if query is None:
+            query = {}
 
         # Remove internal spot arg
         query.pop('spot', '')
+
+        # Store original recv_window.
+        recv_window = self.recv_window
 
         # Bug fix: change floating whole numbers to integers to prevent
         # auth signature errors.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='pybit',
-    version='1.3.0',
+    version='1.3.1',
     description='Python3 Bybit HTTP/WebSocket API Connector', 
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
traceback error when calling an endpoint which does not pass kwargs (`query=kwargs`)
```
Traceback (most recent call last):
  File "/Users/uk09002ml/Projects/pybit/tests/test.py", line 27, in <module>
    print(session.api_key_info())
  File "/Users/uk09002ml/Projects/pybit/pybit/__init__.py", line 1362, in api_key_info
    return self._submit_request(
  File "/Users/uk09002ml/Projects/pybit/pybit/__init__.py", line 1702, in _submit_request
    query.pop('spot', '')
AttributeError: 'NoneType' object has no attribute 'pop'
```
Affected endpoints: `api_key_info()`, `query_symbol()`, any other which does not pass `kwargs` to `_submit_request()`