### PR TITLE
Calling query_symbol() for spot cause an error

### DIFF
--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -1698,12 +1698,14 @@ class HTTP:
         # Store original recv_window.
         recv_window = self.recv_window
 
-        # Remove internal spot arg
-        query.pop('spot', '')
 
         # Bug fix: change floating whole numbers to integers to prevent
         # auth signature errors.
         if query is not None:
+            
+            # Remove internal spot arg
+            query.pop('spot', '')
+            
             for i in query.keys():
                 if isinstance(query[i], float) and query[i] == int(query[i]):
                     query[i] = int(query[i])


### PR DESCRIPTION
Calling query_symbol() for spot cause an error:

  File "/usr/local/lib/python3.8/site-packages/pybit/__init__.py", line 321, in query_symbol
    return self._submit_request(
  File "/usr/local/lib/python3.8/site-packages/pybit/__init__.py", line 1702, in _submit_request
    query.pop('spot', '')
AttributeError: 'NoneType' object has no attribute 'pop'

Not all methods pass query parameter along with _submit_request and query defaults to None.