### PR TITLE
Patch for Issue #71: websockets fetch test is wrong, and displays an unhandled error in the code

### DIFF
--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -2045,8 +2045,7 @@ class WebSocket:
             topic = self.conform_topic(topic)
         # If the topic given isn't in the initial subscribed list.
         if topic not in self.subscriptions:
-            self.logger.error(f'You aren\'t subscribed to the {topic} topic.')
-            return
+            raise Exception(f"You aren\'t subscribed to the {topic} topic.")
 
         # Pop all trade or execution data on each poll.
         # don't pop order or stop_order data as we will lose valuable state

--- a/tests/test_pybit.py
+++ b/tests/test_pybit.py
@@ -62,6 +62,6 @@ class WebSocketTest(unittest.TestCase):
     # A very simple test to ensure we're getting something from WS.
     def test_websocket(self):
         self.assertNotEqual(
-            ws.fetch(['instrument_info.100ms.BTCUSD']),
+            ws.fetch('instrument_info.100ms.BTCUSD'),
             []
         )


### PR DESCRIPTION
Patch for https://github.com/verata-veritatis/pybit/issues/71.

Note that this creates a new test failure, and that should be fixed seperately.  Its better to have this patch that exposes this error than hiding it.